### PR TITLE
Add -NoGraphics switch 

### DIFF
--- a/HPDrivers.psd1
+++ b/HPDrivers.psd1
@@ -12,7 +12,7 @@
 RootModule = 'HPDrivers.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.4.3'
+ModuleVersion = '1.4.4'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/HPDrivers.psm1
+++ b/HPDrivers.psm1
@@ -254,7 +254,9 @@ function Get-HPDrivers {
         }
 
         # Select drivers from the list of available drivers
-        if (!$NoPrompt) {
+        if (!$NoPrompt -and !$NoGrpahics ) {
+            $SpList = $AvailableDrivers | Where-Object {-Not ($_.Name.Contains("Graphics"))} | Select-Object -Property id, Name, Category, Version, Size, DateReleased | Out-GridView -Title "Select driver(s):" -OutputMode Multiple
+        } ElseIf (!$NoPrompt -and !$NoGrpahics) {
             $SpList = $AvailableDrivers | Select-Object -Property id, Name, Category, Version, Size, DateReleased | Out-GridView -Title "Select driver(s):" -OutputMode Multiple
         }
 
@@ -262,7 +264,7 @@ function Get-HPDrivers {
         # -NoPrompt
         if ($NoPrompt -and !$NoGraphics) {
             $SpList = $AvailableDrivers
-        } ElseIf (NoPrompt -and $NoGraphics) {
+        } ElseIf ($NoPrompt -and $NoGraphics) {
             $SpList = $AvailableDrivers | Where-Object {-Not ($_.Name.Contains("Graphics"))}
         }
 

--- a/HPDrivers.psm1
+++ b/HPDrivers.psm1
@@ -109,6 +109,7 @@ function Get-HPDrivers {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)] [switch]$NoPrompt,
+        [Parameter(Mandatory = $false)] [switch]$NoGraphics,
         [Parameter(Mandatory = $false)] [string]$OsVersion,
         [Parameter(Mandatory = $false)] [switch]$ShowSoftware,
         [Parameter(Mandatory = $false)] [switch]$Overwrite,
@@ -259,8 +260,10 @@ function Get-HPDrivers {
 
         # Select all drivers without prompt
         # -NoPrompt
-        if ($NoPrompt) {
+        if ($NoPrompt -and !$NoGraphics) {
             $SpList = $AvailableDrivers
+        } ElseIf (NoPrompt -and $NoGraphics) {
+            $SpList = $AvailableDrivers | Where-Object {-Not ($_.Name.Contains("Graphics"))}
         }
 
         # Insert a line to the log file
@@ -272,7 +275,7 @@ function Get-HPDrivers {
         # Show list of available drivers
         if ($SpList) {
             Write-Verbose "The script will install the following drivers. Please wait..`n" -Verbose
-            $SpList | Select-Object -Property Id, Name, Version, Size, DateReleased | Format-Table -AutoSize
+            $SpList |  Select-Object -Property Id, Name, Version, Size, DateReleased | Format-Table -AutoSize
         }
         if ($BadLinks) {
             Write-Warning "The following drivers are not available on the HP server `n"


### PR DESCRIPTION
Add a -NoGraphics switch to exclude any drivers with "Graphics" in the name. Useful for if you need to remain on a specific driver version. e.g. HP Z workstations for Graphics/Video editing. 